### PR TITLE
FIX Null Pointer Exception

### DIFF
--- a/calendar/src/org/zkoss/calendar/Calendars.java
+++ b/calendar/src/org/zkoss/calendar/Calendars.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TimeZone;
+import java.util.UUID;
 
 import org.zkoss.calendar.api.CalendarEvent;
 import org.zkoss.calendar.api.CalendarModel;
@@ -453,11 +454,13 @@ public class Calendars extends XulElement {
 		
 	public String getCalendarEventId(CalendarEvent ce) {
 		Object o = _ids.get(ce);
-		if (o == null) {
+		if (o == null && super.getDesktop() != null) {
 			o = ((DesktopCtrl)getDesktop()).getNextUuid(this);
 			_ids.put(o, ce);
 			_ids.put(ce, o);
-		}
+		} else if (o == null) {
+			o = UUID.randomUUID().toString();
+        	}
 		return (String) o;
 	}	
 	


### PR DESCRIPTION
When you try to use the method getCalendarEventId(...) and the parent class returns null for getDesktop() the NPE is thrown.
I added a simple check to avoid to throw NPE and few loc to generate a random UUID in case of lack of the Desktop Object.
